### PR TITLE
Fix non-functional error-check in cpucycles()

### DIFF
--- a/perf_event_open.c
+++ b/perf_event_open.c
@@ -28,7 +28,7 @@ static inline long long
 cpucycles(void)
 {
 	long long result = 0;
-	if (read(fddev, &result, sizeof(result)) < sizeof(result)) return 0;
+	if (read(fddev, &result, sizeof(result)) < (ssize_t)sizeof(result)) return 0;
 	return result;
 }
 


### PR DESCRIPTION
read() returns a ssize_t while sizeof() is a
size_t. Thus the ssize_t is promoted to an
unsigned integer. This leads to
misinterpreting a -1 returned by read()
on an error condition as successful read().

This commit fixes this by casting the sizeof()
to an ssize_t. Alternatively a == -1 check should
be sufficient as one would expect perf
to make the requested data available in proper size
or fail accordingly.

Signed-off-by: Gnoxter gnoxter@linuxlounge.net
