### PR TITLE
enable user-mode access to CNTVCT timer register

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# User-mode access to ARM PMU cycle counters
+# User-mode access to cycle counters in ARM PMU and CNTVCT timer
 
 This repository contains a kernel module and library.
 
@@ -25,6 +25,9 @@ $ sudo make runtests
   * ODROID-U2
     * Exynos 4 Quad, 1.7gHz Cortex-A9
     * Ubuntu/Linaro 12.10 derivative
+  * ODROID-XU4
+    * Exynos 5422 4xA15+4xA7 Octa big.LITTLE, 2GHz
+    * Arch Linux on ARM
 
 TBD: PandaBoard.
 


### PR DESCRIPTION
CNTVCT: Virtual Count Register --  a 64-bit counter part of Virtual Memory
System Architecture.  Section B4.1.34 in ARM Architecture Reference Manual
ARMv7-A/ARMv7-R

FFTW library, for example, already has support for this cycle counter, so it
would be nice to enable it from here.

Tested both the existing PMU code and the new CNTVCT code on XU4.

Signed-off-by: Alexei Colin <ac@alexeicolin.com>